### PR TITLE
Initial port from Windows.Devices to System.Device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,6 @@ paket-files/
 
 #SoundCloud
 *.sonarqube/
+
+#VS Code
+.vscode/

--- a/SIM800H/Eclo.nF.Extensions/Eclo.nF.SerialDeviceExtensions.cs
+++ b/SIM800H/Eclo.nF.Extensions/Eclo.nF.SerialDeviceExtensions.cs
@@ -3,9 +3,9 @@
 // See LICENSE file in the project root for full license information.
 ////
 
-using Windows.Devices.SerialCommunication;
-using Windows.Storage.Streams;
 using System;
+using System.IO;
+using System.IO.Ports;
 
 namespace Eclo.nF.Extensions
 {
@@ -16,70 +16,71 @@ namespace Eclo.nF.Extensions
         /// </summary>
         /// <param name="serialDevice">Serial port to write string to</param>
         /// <param name="text">string to write</param>
-        public static void Write(this SerialDevice serialDevice, string text)
+        public static void Write(this SerialPort serialDevice, string text)
         {
             if (text != null)
             {
                 // setup data writer for Serial Device output stream
-                DataWriter outputDataWriter = new DataWriter(serialDevice.OutputStream);
+                StreamWriter outputDataWriter = new StreamWriter(serialDevice.BaseStream);
                 // write string to Serial Device output stream using data writer
                 // (this doesn't send any data, just writes to the stream)
-                var bytesWritten = outputDataWriter.WriteString(text);
+                ////var bytesWritten = outputDataWriter.Write(text);
+                outputDataWriter.Write(text);
                 // calling the 'Store' method on the data writer actually sends the data
-                var bw1 = outputDataWriter.Store();
+                ////var bw1 = outputDataWriter.Store();
             }
         }
-        public static void WriteBytes(this SerialDevice serialDevice, byte[] buffer, int offset, int count)
+        public static void WriteBytes(this SerialPort serialDevice, byte[] buffer, int offset, int count)
         {
             if (buffer != null)
             {
                 byte[] tmp = new byte[count];
                 Array.Copy(buffer, offset, tmp, 0, count);
                 // setup data writer for Serial Device output stream
-                DataWriter outputDataWriter = new DataWriter(serialDevice.OutputStream);
+                StreamWriter outputDataWriter = new StreamWriter(serialDevice.BaseStream);
                 // write string to Serial Device output stream using data writer
                 // (this doesn't send any data, just writes to the stream)
-                outputDataWriter.WriteBytes(tmp);
+                outputDataWriter.Write(tmp);
                 // calling the 'Store' method on the data writer actually sends the data
-                var bw1 = outputDataWriter.Store();
+                ////var bw1 = outputDataWriter.Store();
             }
         }
 
-        public static byte ReadByte(this SerialDevice serialDevice, DataReader inputDataReader)
+        ////public static byte ReadByte(this SerialPort serialDevice, StreamReader inputDataReader)
+        ////{
+        ////    // read one bytes from the Serial Device input stream
+        ////    var byteRead = inputDataReader.Load(1);
+        ////    return inputDataReader.ReadByte();
+        ////}
+
+        ////public static int ReadChars(this SerialPort serialDevice, StreamReader inputDataReader, ref char[] buffer, int offset, int count)
+        ////{
+        ////    byte[] tempBuffer = new byte[count];
+
+        ////    // load count bytes to be read
+        ////    var bytesRead = inputDataReader.ReadBlock(buffer, offset, tempBuffer.Length);
+
+        ////    // copy temp buffer content to buffer arg, casting to char
+        ////    foreach (byte b in tempBuffer)
+        ////    {
+        ////        buffer[offset++] = (char)b;
+        ////    }
+
+        ////    // release buffer memory
+        ////    tempBuffer = null;
+
+        ////    return (int)bytesRead;
+        ////}
+
+        public static void DiscardInBuffer(this SerialPort serialDevice)
         {
-            // read one bytes from the Serial Device input stream
-            var byteRead = inputDataReader.Load(1);
-            return inputDataReader.ReadByte();
-        }
-
-        public static int ReadChars(this SerialDevice serialDevice, DataReader inputDataReader, ref char[] buffer, int offset, int count)
-        {
-            byte[] tempBuffer = new byte[count];
-
-            // load count bytes to be read
-            var bytesRead = inputDataReader.Load((uint)count);
-            inputDataReader.ReadBytes(tempBuffer);
-
-            // copy temp buffer content to buffer arg, casting to char
-            foreach (byte b in tempBuffer)
-            {
-                buffer[offset++] = (char)b;
-            }
-
-            // release buffer memory
-            tempBuffer = null;
-
-            return (int)bytesRead;
-        }
-
-        public static void DiscardInBuffer(this SerialDevice serialDevice)
-        {
-            using (var inputDataReader = new DataReader(serialDevice.InputStream))
-            {
-                var bytesRead = inputDataReader.Load(serialDevice.BytesToRead);
-                if(bytesRead > 0)
-                    inputDataReader.ReadString(bytesRead);
-            }
+            serialDevice.ReadExisting();
+            ////using (var inputDataReader = new StreamReader(serialDevice.BaseStream))
+            ////{
+            ////    var bytesRead = inputDataReader.ReadToEnd(); //// Load(serialDevice.BytesToRead);
+            ////    ////if(bytesRead > 0)
+            ////    ////    inputDataReader.Read(bytesRead);
+            ////}
         }
     }
 }

--- a/SIM800H/Http/HttpByteBuffer.cs
+++ b/SIM800H/Http/HttpByteBuffer.cs
@@ -4,7 +4,6 @@
 ////
 
 using System;
-using Windows.Storage.Streams;
 
 namespace Eclo.nanoFramework.SIM800H.Http
 {

--- a/SIM800H/Http/HttpWebRequest.cs
+++ b/SIM800H/Http/HttpWebRequest.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.IO;
-using Windows.Storage.Streams;
 
 namespace Eclo.nanoFramework.SIM800H
 {
@@ -43,7 +42,7 @@ namespace Eclo.nanoFramework.SIM800H
         /// </summary>
         private Uri _originalUrl;
 
-        internal InMemoryRandomAccessStream _requestStream;
+        internal MemoryStream _requestStream;
 
         /// <summary>
         /// Data to be sent in the request.
@@ -173,11 +172,11 @@ namespace Eclo.nanoFramework.SIM800H
         /// </summary>
         /// <returns>A <b>Stream</b> to use to write request data.</returns>
         /// <remarks>Used for POST requests.</remarks>
-        public InMemoryRandomAccessStream GetRequestStream()
+        public MemoryStream GetRequestStream()
         {
             if (_requestStream == null)
             {
-                _requestStream = new InMemoryRandomAccessStream();
+                _requestStream = new MemoryStream();
             }
 
             return _requestStream;

--- a/SIM800H/Http/HttpWebRequestAsyncResult.cs
+++ b/SIM800H/Http/HttpWebRequestAsyncResult.cs
@@ -8,7 +8,6 @@ using System.Collections;
 using System.Text;
 using System.Threading;
 using Eclo.nF.Extensions;
-using Windows.Storage.Streams;
 
 namespace Eclo.nanoFramework.SIM800H
 {
@@ -234,18 +233,18 @@ namespace Eclo.nanoFramework.SIM800H
                         {
                             // caller has filled request stream
 
-                            IBuffer buffer = (IBuffer)new Http.HttpByteBuffer(64);
+                            var buffer = new Http.HttpByteBuffer(64);
 
                             // reset position of stream to start reading from the beginning
-                            _httpRequest._requestStream.Seek(0);
+                            _httpRequest._requestStream.Seek(0, System.IO.SeekOrigin.Begin);
 
                             while (index < (int)_httpRequest._requestStream.Length)
                             {
                                 // adjust chunk size
-                                chunkSize = System.Math.Min(chunkSize, (int)_httpRequest._requestStream.Length - index);
+                                chunkSize = Math.Min(chunkSize, (int)_httpRequest._requestStream.Length - index);
 
                                 // read chunk
-                                _httpRequest._requestStream.Read(buffer, (uint)chunkSize, Windows.Storage.Streams.InputStreamOptions.Partial);
+                                _httpRequest._requestStream.Read(buffer.Data, 0, chunkSize); //, Windows.Storage.Streams.InputStreamOptions.Partial);
 
                                 // check if UART TX buffer needs to be flushed
                                 /*TBD                                if (SIM800H.Instance._serialDevice.BytesToWrite > chunkSize)

--- a/SIM800H/Http/HttpWebResponse.cs
+++ b/SIM800H/Http/HttpWebResponse.cs
@@ -6,7 +6,6 @@
 using System;
 using System.IO;
 using System.Text;
-using Windows.Storage.Streams;
 
 namespace Eclo.nanoFramework.SIM800H
 {
@@ -61,14 +60,16 @@ namespace Eclo.nanoFramework.SIM800H
             this.Headers = new WebHeaderCollection();
         }
 
-        public InMemoryRandomAccessStream GetResponseStream()
+        public MemoryStream GetResponseStream()
         {
-            InMemoryRandomAccessStream stream = new InMemoryRandomAccessStream();
-            if(this.BodyData != string.Empty)
-                stream.Write(Encoding.UTF8.GetBytes(this.BodyData));//, 0, this.BodyData.Length);
-
+            MemoryStream stream = new MemoryStream();
+            if (this.BodyData != string.Empty)
+            {
+                var buff = Encoding.UTF8.GetBytes(this.BodyData);
+                stream.Write(buff, 0, buff.Length);//, 0, this.BodyData.Length);
+            }
             // need to reset stream position to allow reading
-            stream.Seek(0);
+            stream.Seek(0, SeekOrigin.Begin);
 
             return stream;
         }

--- a/SIM800H/IBuffer.cs
+++ b/SIM800H/IBuffer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Text;
+
+namespace Eclo.nanoFramework.SIM800H
+{   
+    /// <summary>
+    /// Represents a referenced array of bytes used by byte stream read and write interfaces.
+    /// Buffer is the class implementation of this interface.
+    /// </summary>
+    public interface IBuffer
+    {
+        /// <summary>
+        /// Gets the maximum number of bytes that the buffer can hold.
+        /// </summary>
+        uint Capacity { get; }
+
+        /// <summary>
+        /// Gets or sets the number of bytes currently in use in the buffer.
+        /// </summary>
+        uint Length { get; set; }
+    }
+}
+

--- a/SIM800H/PowerOnAsyncResult.cs
+++ b/SIM800H/PowerOnAsyncResult.cs
@@ -4,10 +4,10 @@
 ////
 
 using System;
+using System.Device.Gpio;
+using System.Diagnostics;
 using System.Threading;
 using Eclo.nF.Extensions;
-using Windows.Devices.Gpio;
-using Windows.Storage.Streams;
 
 namespace Eclo.nanoFramework.SIM800H
 {
@@ -90,9 +90,9 @@ namespace Eclo.nanoFramework.SIM800H
 #if DEBUG__
                     Debug.WriteLine("Turning module on with power key");
 #endif
-                    SIM800H.Instance._powerKey.Write(GpioPinValue.High);
+                    SIM800H.Instance._powerKey.Write(PinValue.High);
                     Thread.Sleep(1100);
-                    SIM800H.Instance._powerKey.Write(GpioPinValue.Low);
+                    SIM800H.Instance._powerKey.Write(PinValue.Low);
                     Thread.Sleep(3100);
 
 #if DEBUG__
@@ -159,9 +159,9 @@ namespace Eclo.nanoFramework.SIM800H
 #if DEBUG__
                         //Debug.WriteLine("Turning module on with power key");
 #endif
-                        SIM800H.Instance._powerKey.Write(GpioPinValue.High);
+                        SIM800H.Instance._powerKey.Write(PinValue.High);
                         Thread.Sleep(1100);
-                        SIM800H.Instance._powerKey.Write(GpioPinValue.Low);
+                        SIM800H.Instance._powerKey.Write(PinValue.Low);
                         Thread.Sleep(3500);
 
                         // send AT directly to UART so this is not processed as command, waiting for reply, etc

--- a/SIM800H/nanoFramework.SIM800H.nfproj
+++ b/SIM800H/nanoFramework.SIM800H.nfproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
     <SccProjectName>SAK</SccProjectName>
@@ -57,6 +57,7 @@
     <Compile Include="Http\Uri.cs" />
     <Compile Include="Http\WebHeaderCollection.cs" />
     <Compile Include="Http\WebRequest.cs" />
+    <Compile Include="IBuffer.cs" />
     <Compile Include="LocationAndTime.cs" />
     <Compile Include="MMS\MmsClient.cs" />
     <Compile Include="MMS\MmsConfiguration.cs" />
@@ -86,52 +87,36 @@
     <Compile Include="WarningCondition.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Folder Include="Eclo.nF.Extensions\" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="mscorlib">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.9.1\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.11.6\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.2.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Collections.1.2.0\lib\nanoFramework.System.Collections.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Collections">
+      <HintPath>..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.1.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Text.1.1.1\lib\nanoFramework.System.Text.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Text">
+      <HintPath>..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Math.1.4.1\lib\System.Math.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Device.Gpio">
+      <HintPath>..\packages\nanoFramework.System.Device.Gpio.1.1.28\lib\System.Device.Gpio.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.Gpio, Version=1.5.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Windows.Devices.Gpio.1.5.2\lib\Windows.Devices.Gpio.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Ports">
+      <HintPath>..\packages\nanoFramework.System.IO.Ports.1.1.60\lib\System.IO.Ports.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.SerialCommunication, Version=1.3.4.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Windows.Devices.SerialCommunication.1.3.4\lib\Windows.Devices.SerialCommunication.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Streams">
+      <HintPath>..\packages\nanoFramework.System.IO.Streams.1.1.38\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Storage.Streams, Version=1.12.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Windows.Storage.Streams.1.12.2\lib\Windows.Storage.Streams.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Math">
+      <HintPath>..\packages\nanoFramework.System.Math.1.5.29\lib\System.Math.dll</HintPath>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <Import Project="..\packages\Nerdbank.GitVersioning.3.2.31\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\packages\Nerdbank.GitVersioning.3.2.31\build\Nerdbank.GitVersioning.targets')" />

--- a/SIM800H/packages.config
+++ b/SIM800H/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.Gpio" version="1.5.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.SerialCommunication" version="1.3.4" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Storage.Streams" version="1.12.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.28" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Ports" version="1.1.60" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Math" version="1.5.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
 </packages>

--- a/Tests/Features/Features.nfproj
+++ b/Tests/Features/Features.nfproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
     <SccProjectName>SAK</SccProjectName>
@@ -30,45 +30,29 @@
     <ProjectReference Include="..\..\SIM800H\nanoFramework.SIM800H.nfproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="mscorlib">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.1\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.6\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.2.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0\lib\nanoFramework.System.Collections.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Collections">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.1.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1\lib\nanoFramework.System.Text.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Text">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Math.1.4.1\lib\System.Math.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Device.Gpio">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Gpio.1.1.28\lib\System.Device.Gpio.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.Gpio, Version=1.5.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Devices.Gpio.1.5.2\lib\Windows.Devices.Gpio.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Ports">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Ports.1.1.60\lib\System.IO.Ports.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.SerialCommunication, Version=1.3.4.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Devices.SerialCommunication.1.3.4\lib\Windows.Devices.SerialCommunication.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Streams">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.38\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Storage.Streams, Version=1.12.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Storage.Streams.1.12.2\lib\Windows.Storage.Streams.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Math">
+      <HintPath>..\..\packages\nanoFramework.System.Math.1.5.29\lib\System.Math.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Features/Program.cs
+++ b/Tests/Features/Program.cs
@@ -6,15 +6,16 @@
 using Eclo.nanoFramework.SIM800H;
 using SIM800HSamples;
 using System;
+using System.IO.Ports;
 using System.Threading;
-using Windows.Devices.Gpio;
-using Windows.Devices.SerialCommunication;
+using System.Device.Gpio;
+using System.Diagnostics;
 
 namespace Features
 {
     public class Program
     {
-        static SerialDevice _serialDevice;
+        static SerialPort _serialDevice;
 
         public static void Main()
         {
@@ -36,11 +37,10 @@ namespace Features
             // we just need to pass a serial port and an output signal to control the "power key" signal
 
             // open COM
-            _serialDevice = SerialDevice.FromId("COM2");
+            _serialDevice = new SerialPort("COM2");
 
             // SIM800H signal for "power key"
-            GpioPin sim800PowerKey = GpioController.GetDefault().OpenPin(0 * 1 + 10, GpioSharingMode.Exclusive);
-            sim800PowerKey.SetDriveMode(GpioPinDriveMode.Output);
+            GpioPin sim800PowerKey = new GpioController().OpenPin(0 * 1 + 10, PinMode.Output);            
 
             Debug.WriteLine("... Configuring SIM800H ...");
 

--- a/Tests/Features/packages.config
+++ b/Tests/Features/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.Gpio" version="1.5.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.SerialCommunication" version="1.3.4" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Storage.Streams" version="1.12.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.28" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Ports" version="1.1.60" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Math" version="1.5.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
 </packages>

--- a/Tests/HTTP Requests/ByteBuffer.cs
+++ b/Tests/HTTP Requests/ByteBuffer.cs
@@ -3,8 +3,8 @@
 // See LICENSE file in the project root for full license information.
 ////
 
+using Eclo.nanoFramework.SIM800H;
 using System;
-using Windows.Storage.Streams;
 
 namespace HTTP_Requests
 {

--- a/Tests/HTTP Requests/HTTP Requests.nfproj
+++ b/Tests/HTTP Requests/HTTP Requests.nfproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
     <SccProjectName>SAK</SccProjectName>
@@ -32,46 +32,28 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.9.0-preview.5\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.6\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.1\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Collections">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.2.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0\lib\nanoFramework.System.Collections.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Text">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.1.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1\lib\nanoFramework.System.Text.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Device.Gpio">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Gpio.1.1.28\lib\System.Device.Gpio.dll</HintPath>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Math.1.4.1\lib\System.Math.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Ports">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Ports.1.1.60\lib\System.IO.Ports.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.Gpio, Version=1.5.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Devices.Gpio.1.5.2\lib\Windows.Devices.Gpio.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Streams">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.38\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.SerialCommunication, Version=1.3.4.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Devices.SerialCommunication.1.3.4\lib\Windows.Devices.SerialCommunication.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
-    </Reference>
-    <Reference Include="Windows.Storage.Streams, Version=1.12.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Storage.Streams.1.12.2\lib\Windows.Storage.Streams.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Math">
+      <HintPath>..\..\packages\nanoFramework.System.Math.1.5.29\lib\System.Math.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/HTTP Requests/Program.cs
+++ b/Tests/HTTP Requests/Program.cs
@@ -8,15 +8,15 @@ using SIM800HSamples;
 using System;
 using System.Text;
 using System.Threading;
-using Windows.Devices.Gpio;
-using Windows.Devices.SerialCommunication;
-using Windows.Storage.Streams;
+using System.Device.Gpio;
+using System.IO.Ports;
+using System.Diagnostics;
 
 namespace HTTP_Requests
 {
     public class Program
     {
-        static SerialDevice _serialDevice;
+        static SerialPort _serialDevice;
 
         private const string APNConfigString = "net2.vodafone.pt|vodafone|vodafone";
         private const string thingsSpeakApiKey = "G4AVDUPU27ZC899X";
@@ -41,11 +41,10 @@ namespace HTTP_Requests
             // we just need to pass a serial port and an output signal to control the "power key" signal
 
             // open COM
-            _serialDevice = SerialDevice.FromId("COM2");
+            _serialDevice = new SerialPort("COM2");
 
             // SIM800H signal for "power key"
-            GpioPin sim800PowerKey = GpioController.GetDefault().OpenPin(0 * 1 + 10, GpioSharingMode.Exclusive);
-            sim800PowerKey.SetDriveMode(GpioPinDriveMode.Output);
+            GpioPin sim800PowerKey = new GpioController().OpenPin(0 * 1 + 10, PinMode.Output);
 
             Debug.WriteLine("... Configuring SIM800H ...");
 

--- a/Tests/HTTP Requests/packages.config
+++ b/Tests/HTTP Requests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.Gpio" version="1.5.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.SerialCommunication" version="1.3.4" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Storage.Streams" version="1.12.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.28" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Ports" version="1.1.60" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Math" version="1.5.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
 </packages>

--- a/Tests/MMS Send Sync/MMS Send Sync.nfproj
+++ b/Tests/MMS Send Sync/MMS Send Sync.nfproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
     <SccProjectName>SAK</SccProjectName>
@@ -46,56 +46,34 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.9.0-preview.5\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nanoFramework.ResourceManager">
+      <HintPath>..\..\packages\nanoFramework.ResourceManager.1.2.13\lib\nanoFramework.ResourceManager.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.ResourceManager, Version=1.1.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.ResourceManager.1.1.2\lib\nanoFramework.ResourceManager.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.6\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.1\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.Runtime.Native">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.6.6\lib\nanoFramework.Runtime.Native.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Native, Version=1.5.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.5.1\lib\nanoFramework.Runtime.Native.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Collections">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.2.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0\lib\nanoFramework.System.Collections.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Text">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.1.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1\lib\nanoFramework.System.Text.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Device.Gpio">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Gpio.1.1.28\lib\System.Device.Gpio.dll</HintPath>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Math.1.4.1\lib\System.Math.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Ports">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Ports.1.1.60\lib\System.IO.Ports.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.Gpio, Version=1.5.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Devices.Gpio.1.5.2\lib\Windows.Devices.Gpio.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Streams">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.38\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.SerialCommunication, Version=1.3.4.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Devices.SerialCommunication.1.3.4\lib\Windows.Devices.SerialCommunication.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
-    </Reference>
-    <Reference Include="Windows.Storage.Streams, Version=1.12.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Storage.Streams.1.12.2\lib\Windows.Storage.Streams.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Math">
+      <HintPath>..\..\packages\nanoFramework.System.Math.1.5.29\lib\System.Math.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />

--- a/Tests/MMS Send Sync/Program.cs
+++ b/Tests/MMS Send Sync/Program.cs
@@ -7,14 +7,15 @@ using Eclo.nanoFramework.SIM800H;
 using SIM800HSamples;
 using System;
 using System.Threading;
-using Windows.Devices.Gpio;
-using Windows.Devices.SerialCommunication;
+using System.Device.Gpio;
+using System.IO.Ports;
+using System.Diagnostics;
 
 namespace MMS_Send_Sync
 {
     public class Program
     {
-        static SerialDevice _serialDevice;
+        static SerialPort _serialDevice;
 
         // Vodafone PT config
         private const string mmsApnConfigString = "vas.vodafone.pt|vas|vas";
@@ -211,11 +212,10 @@ namespace MMS_Send_Sync
             // we just need to pass a serial port and an output signal to control the "power key" signal
 
             // open COM
-            _serialDevice = SerialDevice.FromId("COM2");
+            _serialDevice = new SerialPort("COM2");
 
             // SIM800H signal for "power key"
-            GpioPin sim800PowerKey = GpioController.GetDefault().OpenPin(0 * 1 + 10, GpioSharingMode.Exclusive);
-            sim800PowerKey.SetDriveMode(GpioPinDriveMode.Output);
+            GpioPin sim800PowerKey = new GpioController().OpenPin(0 * 1 + 10, PinMode.Output);
 
             Debug.WriteLine("... Configuring SIM800H ...");
 

--- a/Tests/MMS Send Sync/packages.config
+++ b/Tests/MMS Send Sync/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.ResourceManager" version="1.1.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Native" version="1.5.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.Gpio" version="1.5.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.SerialCommunication" version="1.3.4" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Storage.Streams" version="1.12.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
+  <package id="nanoFramework.ResourceManager" version="1.2.13" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Native" version="1.6.6" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.28" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Ports" version="1.1.60" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Math" version="1.5.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
 </packages>

--- a/Tests/Network Location and Time/Network Location and Time.nfproj
+++ b/Tests/Network Location and Time/Network Location and Time.nfproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
     <SccProjectName>SAK</SccProjectName>
@@ -31,46 +31,28 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.9.0-preview.5\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.6\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.1\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Collections">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.2.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0\lib\nanoFramework.System.Collections.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Text">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.1.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1\lib\nanoFramework.System.Text.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Device.Gpio">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Gpio.1.1.28\lib\System.Device.Gpio.dll</HintPath>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Math.1.4.1\lib\System.Math.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Ports">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Ports.1.1.60\lib\System.IO.Ports.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.Gpio, Version=1.5.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Devices.Gpio.1.5.2\lib\Windows.Devices.Gpio.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Streams">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.38\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.SerialCommunication, Version=1.3.4.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Devices.SerialCommunication.1.3.4\lib\Windows.Devices.SerialCommunication.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
-    </Reference>
-    <Reference Include="Windows.Storage.Streams, Version=1.12.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Storage.Streams.1.12.2\lib\Windows.Storage.Streams.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Math">
+      <HintPath>..\..\packages\nanoFramework.System.Math.1.5.29\lib\System.Math.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Network Location and Time/Program.cs
+++ b/Tests/Network Location and Time/Program.cs
@@ -7,14 +7,15 @@ using Eclo.nanoFramework.SIM800H;
 using SIM800HSamples;
 using System;
 using System.Threading;
-using Windows.Devices.Gpio;
-using Windows.Devices.SerialCommunication;
+using System.Device.Gpio;
+using System.IO.Ports;
+using System.Diagnostics;
 
 namespace Network_Location_and_Time
 {
     public class Program
     {
-        static SerialDevice _serialDevice;
+        static SerialPort _serialDevice;
         private const string APNConfigString = "net2.vodafone.pt|vodafone|vodafone";
         private const string mmsApnConfigString = "vas.vodafone.pt|vas|vas";
 
@@ -38,11 +39,10 @@ namespace Network_Location_and_Time
             // we just need to pass a serial port and an output signal to control the "power key" signal
 
             // open COM
-            _serialDevice = SerialDevice.FromId("COM2");
+            _serialDevice = new SerialPort("COM2");
 
             // SIM800H signal for "power key"
-            GpioPin sim800PowerKey = GpioController.GetDefault().OpenPin(0 * 1 + 10, GpioSharingMode.Exclusive);
-            sim800PowerKey.SetDriveMode(GpioPinDriveMode.Output);
+            GpioPin sim800PowerKey = new GpioController().OpenPin(0 * 1 + 10, PinMode.Output);
 
             Debug.WriteLine("... Configuring SIM800H ...");
 

--- a/Tests/Network Location and Time/packages.config
+++ b/Tests/Network Location and Time/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.Gpio" version="1.5.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.SerialCommunication" version="1.3.4" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Storage.Streams" version="1.12.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.28" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Ports" version="1.1.60" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Math" version="1.5.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
 </packages>

--- a/Tests/SMS Receive/Program.cs
+++ b/Tests/SMS Receive/Program.cs
@@ -6,15 +6,16 @@
 using Eclo.nanoFramework.SIM800H;
 using SIM800HSamples;
 using System;
+using System.IO.Ports;
 using System.Threading;
-using Windows.Devices.Gpio;
-using Windows.Devices.SerialCommunication;
+using System.Device.Gpio;
+using System.Diagnostics;
 
 namespace SMS_Receive
 {
     public class Program
     {
-        static SerialDevice _serialDevice;
+        static SerialPort _serialDevice;
 
         public static void Main()
         {
@@ -36,11 +37,10 @@ namespace SMS_Receive
             // we just need to pass a serial port and an output signal to control the "power key" signal
 
             // open COM
-            _serialDevice = SerialDevice.FromId("COM2");
+            _serialDevice = new SerialPort("COM2");
 
             // SIM800H signal for "power key"
-            GpioPin sim800PowerKey = GpioController.GetDefault().OpenPin(0 * 1 + 10, GpioSharingMode.Exclusive);
-            sim800PowerKey.SetDriveMode(GpioPinDriveMode.Output);
+            GpioPin sim800PowerKey = new GpioController().OpenPin(0 * 1 + 10, PinMode.Output);
 
             Debug.WriteLine("... Configuring SIM800H ...");
 

--- a/Tests/SMS Receive/SMS Receive.nfproj
+++ b/Tests/SMS Receive/SMS Receive.nfproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
     <SccProjectName>SAK</SccProjectName>
@@ -31,46 +31,28 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.9.0-preview.5\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.6\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.1\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Collections">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.2.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0\lib\nanoFramework.System.Collections.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Text">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.1.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1\lib\nanoFramework.System.Text.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Device.Gpio">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Gpio.1.1.28\lib\System.Device.Gpio.dll</HintPath>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Math.1.4.1\lib\System.Math.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Ports">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Ports.1.1.60\lib\System.IO.Ports.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.Gpio, Version=1.5.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Devices.Gpio.1.5.2\lib\Windows.Devices.Gpio.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Streams">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.38\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.SerialCommunication, Version=1.3.4.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Devices.SerialCommunication.1.3.4\lib\Windows.Devices.SerialCommunication.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
-    </Reference>
-    <Reference Include="Windows.Storage.Streams, Version=1.12.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Storage.Streams.1.12.2\lib\Windows.Storage.Streams.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Math">
+      <HintPath>..\..\packages\nanoFramework.System.Math.1.5.29\lib\System.Math.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/SMS Receive/packages.config
+++ b/Tests/SMS Receive/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.Gpio" version="1.5.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.SerialCommunication" version="1.3.4" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Storage.Streams" version="1.12.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.28" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Ports" version="1.1.60" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Math" version="1.5.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
 </packages>

--- a/Tests/SMS batch sending/Program.cs
+++ b/Tests/SMS batch sending/Program.cs
@@ -6,15 +6,18 @@
 using Eclo.nanoFramework.SIM800H;
 using SIM800HSamples;
 using System;
+using System.IO.Ports;
 using System.Threading;
-using Windows.Devices.Gpio;
-using Windows.Devices.SerialCommunication;
+using System.Device.Gpio;
+using System.Diagnostics;
+using nanoFramework.Hardware.Esp32;
 
 namespace SMS_batch_sending
 {
     public class Program
     {
-        static SerialDevice _serialDevice;
+        // IMPORTANT: this sample has been adjusted to work with ESP32.
+        static SerialPort _serialDevice;
 
         private static string smsDestination = "<destination phone number>";
 
@@ -37,12 +40,14 @@ namespace SMS_batch_sending
             // initialization of the module is very simple 
             // we just need to pass a serial port and an output signal to control the "power key" signal
 
+            Configuration.SetPinFunction(33, DeviceFunction.COM2_RX);
+            Configuration.SetPinFunction(32, DeviceFunction.COM2_TX);
+
             // open COM
-            _serialDevice = SerialDevice.FromId("COM2");
+            _serialDevice = new SerialPort("COM2");
 
             // SIM800H signal for "power key"
-            GpioPin sim800PowerKey = GpioController.GetDefault().OpenPin(0 * 1 + 10, GpioSharingMode.Exclusive);
-            sim800PowerKey.SetDriveMode(GpioPinDriveMode.Output);
+            GpioPin sim800PowerKey = new GpioController().OpenPin(15, PinMode.Output);
 
             Debug.WriteLine("... Configuring SIM800H ...");
 

--- a/Tests/SMS batch sending/SMS Batch Sending.nfproj
+++ b/Tests/SMS batch sending/SMS Batch Sending.nfproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
     <SccProjectName>SAK</SccProjectName>
@@ -31,46 +31,31 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.9.0-preview.5\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nanoFramework.Hardware.Esp32">
+      <HintPath>..\..\packages\nanoFramework.Hardware.Esp32.1.6.3\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.1\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.6\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.2.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0\lib\nanoFramework.System.Collections.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Collections">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.1.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1\lib\nanoFramework.System.Text.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.System.Text">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Math.1.4.1\lib\System.Math.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Device.Gpio">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Gpio.1.1.28\lib\System.Device.Gpio.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.Gpio, Version=1.5.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Devices.Gpio.1.5.2\lib\Windows.Devices.Gpio.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Ports">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Ports.1.1.60\lib\System.IO.Ports.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Devices.SerialCommunication, Version=1.3.4.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Devices.SerialCommunication.1.3.4\lib\Windows.Devices.SerialCommunication.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.IO.Streams">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.38\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="Windows.Storage.Streams, Version=1.12.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Windows.Storage.Streams.1.12.2\lib\Windows.Storage.Streams.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Math">
+      <HintPath>..\..\packages\nanoFramework.System.Math.1.5.29\lib\System.Math.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/SMS batch sending/packages.config
+++ b/Tests/SMS batch sending/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.Gpio" version="1.5.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.SerialCommunication" version="1.3.4" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Storage.Streams" version="1.12.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hardware.Esp32" version="1.6.3" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.28" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Ports" version="1.1.60" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Math" version="1.5.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
 </packages>

--- a/nanoFramework.SIM800H.sln
+++ b/nanoFramework.SIM800H.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2041
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33205.214
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "nanoFramework.SIM800H", "SIM800H\nanoFramework.SIM800H.nfproj", "{DD3C3335-BD8E-46DA-B173-23C14E3BFB7B}"
 EndProject


### PR DESCRIPTION
This PR to bring work on migrating from Windows.Devices to System.Device for Gpio and System.IO.Ports.
This needs to be intensively tested.

Initial code is most of the time kept on purpose to facilitate the comparison when having the solution cloned and open. It's not much for the PR review.